### PR TITLE
FIX: Call boundAvatar() directly

### DIFF
--- a/assets/javascripts/app/helpers/animated-bound-avatar.js
+++ b/assets/javascripts/app/helpers/animated-bound-avatar.js
@@ -3,7 +3,7 @@ import { prefersReducedMotion } from "discourse/lib/utilities";
 import boundAvatar from "discourse/helpers/bound-avatar";
 
 export default htmlHelper((user, size) => {
-  const avatar = boundAvatar.compute([user, size], {});
+  const avatar = boundAvatar(user, size);
   if (user.animated_avatar != null && !prefersReducedMotion()) {
     avatar.string = avatar.string.replace(/\.png/, ".gif");
   }


### PR DESCRIPTION
Fixes user pages outright breaking since discourse/discourse#22385