### PR TITLE
Fix breaking bug with change in avatar object structure

### DIFF
--- a/assets/javascripts/app/helpers/animated-bound-avatar.js
+++ b/assets/javascripts/app/helpers/animated-bound-avatar.js
@@ -4,10 +4,9 @@ import { htmlHelper } from "discourse-common/lib/helpers";
 
 export default htmlHelper((user, size) => {
   const avatar = boundAvatar(user, size);
-  if (avatar) {
-    if (user.animated_avatar != null && !prefersReducedMotion()) {
-      avatar.string = avatar.string.replace(/\.png/, ".gif");
-    }
+  if (user.animated_avatar != null && !prefersReducedMotion()) {
+    console.log(avatar);
+    //avatar.string = avatar.string.replace(/\.png/, ".gif");
   }
   return avatar;
 });

--- a/assets/javascripts/app/helpers/animated-bound-avatar.js
+++ b/assets/javascripts/app/helpers/animated-bound-avatar.js
@@ -4,8 +4,10 @@ import { htmlHelper } from "discourse-common/lib/helpers";
 
 export default htmlHelper((user, size) => {
   const avatar = boundAvatar(user, size);
-  if (user.animated_avatar != null && !prefersReducedMotion()) {
-    avatar.string = avatar.string.replace(/\.png/, ".gif");
+  if (avatar) {
+    if (user.animated_avatar != null && !prefersReducedMotion()) {
+      avatar.string = avatar.string.replace(/\.png/, ".gif");
+    }
   }
   return avatar;
 });

--- a/assets/javascripts/app/helpers/animated-bound-avatar.js
+++ b/assets/javascripts/app/helpers/animated-bound-avatar.js
@@ -4,9 +4,16 @@ import { htmlHelper } from "discourse-common/lib/helpers";
 
 export default htmlHelper((user, size) => {
   const avatar = boundAvatar(user, size);
-  if (user.animated_avatar != null && !prefersReducedMotion()) {
-    console.log(avatar);
-    avatar.__string = avatar.__string.replace(/\.png/, ".gif");
+  if (avatar) {
+    if (user.animated_avatar != null && !prefersReducedMotion()) {
+      if (avatar.__string) {
+        avatar.__string = avatar.__string.replace(/\.png/, ".gif");
+      } else {
+        console.warn('discourse-animated-avatar: The avatar string variable has changed, probably after an update of Discourse. Falling back on static avatar. The object is now ', avatar);
+      }
+    }
+  } else {
+    console.warn('discourse-animated-avatar: Cannot find the avatar object, probably after an update of Discourse. Falling back on static avatar.');
   }
   return avatar;
 });

--- a/assets/javascripts/app/helpers/animated-bound-avatar.js
+++ b/assets/javascripts/app/helpers/animated-bound-avatar.js
@@ -6,7 +6,7 @@ export default htmlHelper((user, size) => {
   const avatar = boundAvatar(user, size);
   if (user.animated_avatar != null && !prefersReducedMotion()) {
     console.log(avatar);
-    //avatar.string = avatar.string.replace(/\.png/, ".gif");
+    avatar.__string = avatar.__string.replace(/\.png/, ".gif");
   }
   return avatar;
 });


### PR DESCRIPTION
attribute that contains the string changed from `avatar.string` to `avatar.__string`
Adding also some checks and meaningful messages to notify if changes might break the js again, while falling back onto static avatar instead of breaking the page.