### PR TITLE
FIX: Avoid accessing/mutating internal SafeString properties

### DIFF
--- a/assets/javascripts/app/helpers/animated-bound-avatar.js
+++ b/assets/javascripts/app/helpers/animated-bound-avatar.js
@@ -5,7 +5,7 @@ import { htmlHelper } from "discourse-common/lib/helpers";
 export default htmlHelper((user, size) => {
   const avatar = boundAvatar(user, size);
   if (user.animated_avatar != null && !prefersReducedMotion()) {
-    avatar.string = avatar.string.replace(/\.png/, ".gif");
+    return avatar.toString().replace(/\.png/, ".gif");
   }
   return avatar;
 });


### PR DESCRIPTION
Ember internally changed from `.string` to `.__string` which broke this logic. Better to avoid reaching for those private APIs altogether.

htmlHelper already applies `htmlSafe()` on the return value, so no need to do it manually.