### PR TITLE
FIX: Preserve animation in optimized GIF avatars

### DIFF
--- a/lib/discourse_animated_avatars/optimized_image_extension.rb
+++ b/lib/discourse_animated_avatars/optimized_image_extension.rb
@@ -21,6 +21,15 @@ module DiscourseAnimatedAvatars
           %W[--#{resize_method} #{dimensions} --optimize=3 --output #{to} #{from}],
         )
       end
+
+      # Override resize to preserve animation for GIFs
+      def resize(from, to, width, height, opts = {})
+        if opts[:upload_id]
+          upload = Upload.find_by(id: opts[:upload_id])
+          return resize_animated(from, to, width, height, opts) if upload&.extension == "gif"
+        end
+        super
+      end
     end
   end
 end

--- a/lib/discourse_animated_avatars/optimized_image_extension.rb
+++ b/lib/discourse_animated_avatars/optimized_image_extension.rb
@@ -26,7 +26,17 @@ module DiscourseAnimatedAvatars
       def resize(from, to, width, height, opts = {})
         if opts[:upload_id]
           upload = Upload.find_by(id: opts[:upload_id])
-          return resize_animated(from, to, width, height, opts) if upload&.extension == "gif"
+          if upload&.extension == "gif"
+            # Try to use gifsicle if available
+            begin
+              return resize_animated(from, to, width, height, opts)
+            rescue => e
+              # Gifsicle not available or failed, log warning and fall back to default
+              Rails.logger.warn(
+                "Gifsicle resize failed for upload #{upload.id}, falling back to ImageMagick: #{e.message}",
+              )
+            end
+          end
         end
         super
       end

--- a/lib/discourse_animated_avatars/optimized_image_extension.rb
+++ b/lib/discourse_animated_avatars/optimized_image_extension.rb
@@ -24,18 +24,16 @@ module DiscourseAnimatedAvatars
 
       # Override resize to preserve animation for GIFs
       def resize(from, to, width, height, opts = {})
-        if opts[:upload_id]
-          upload = Upload.find_by(id: opts[:upload_id])
-          if upload&.extension == "gif"
-            # Try to use gifsicle if available
-            begin
-              return resize_animated(from, to, width, height, opts)
-            rescue => e
-              # Gifsicle not available or failed, log warning and fall back to default
-              Rails.logger.warn(
-                "Gifsicle resize failed for upload #{upload.id}, falling back to ImageMagick: #{e.message}",
-              )
-            end
+        id = opts[:upload_id]
+        if id && Upload.find_by(id:)&.extension == "gif"
+          # Try to use Gifsicle if available
+          begin
+            return resize_animated(from, to, width, height, opts)
+          rescue => e
+            # Gifsicle not available or failed, log warning and fall back to default
+            Rails.logger.warn(
+              "Gifsicle resize failed for upload #{id}, falling back to ImageMagick: #{e.message}",
+            )
           end
         end
         super

--- a/spec/jobs/create_avatar_thumbnails_spec.rb
+++ b/spec/jobs/create_avatar_thumbnails_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rails_helper"
-
 RSpec.describe Jobs::CreateAvatarThumbnails do
   fab!(:user)
 
@@ -13,8 +11,7 @@ RSpec.describe Jobs::CreateAvatarThumbnails do
   end
 
   it "preserves animation in optimized avatar images",
-     skip: !system("which gifsicle > /dev/null 2>&1") do
-    skip "gifsicle not installed" unless system("which gifsicle > /dev/null 2>&1")
+    skip: !system("which gifsicle > /dev/null 2>&1") do
     file = File.open(animated_gif_path)
     upload =
       UploadCreator.new(file, "animated_avatar.gif", type: "avatar", for_user: user).create_for(
@@ -27,8 +24,7 @@ RSpec.describe Jobs::CreateAvatarThumbnails do
 
     # create optimized images
     Discourse.avatar_sizes.each do |size|
-      result = OptimizedImage.create_for(upload, size, size)
-      puts "Created optimized image #{size}x#{size}: #{result.inspect}" if result.nil?
+      OptimizedImage.create_for(upload, size, size)
     end
 
     upload.reload

--- a/spec/jobs/create_avatar_thumbnails_spec.rb
+++ b/spec/jobs/create_avatar_thumbnails_spec.rb
@@ -12,17 +12,17 @@ RSpec.describe Jobs::CreateAvatarThumbnails do
     SiteSetting.authorized_extensions = "gif"
   end
 
-  it "preserves animation in optimized avatar images" do
+  it "preserves animation in optimized avatar images",
+     skip: !system("which gifsicle > /dev/null 2>&1") do
+    skip "gifsicle not installed" unless system("which gifsicle > /dev/null 2>&1")
     file = File.open(animated_gif_path)
-    upload = UploadCreator.new(
-      file,
-      "animated_avatar.gif",
-      type: "avatar",
-      for_user: user,
-    ).create_for(user.id)
+    upload =
+      UploadCreator.new(file, "animated_avatar.gif", type: "avatar", for_user: user).create_for(
+        user.id,
+      )
     file.close
 
-    expect(upload).to be_persisted, "Upload failed: #{upload.errors.full_messages.join(', ')}"
+    expect(upload).to be_persisted, "Upload failed: #{upload.errors.full_messages.join(", ")}"
     expect(upload.animated?).to eq(true)
 
     # create optimized images
@@ -35,7 +35,7 @@ RSpec.describe Jobs::CreateAvatarThumbnails do
 
     # Verify at least one optimized image exists
     expect(upload.optimized_images.count).to be > 0,
-      "No optimized images were created. Check ImageMagick command."
+    "No optimized images were created. Check ImageMagick command."
 
     # Check that optimized images preserve animation (multiple frames)
     upload.optimized_images.each do |optimized_image|
@@ -43,7 +43,7 @@ RSpec.describe Jobs::CreateAvatarThumbnails do
       frame_count = `identify "#{optimized_path}" 2>/dev/null | wc -l`.strip.to_i
 
       expect(frame_count).to be > 1,
-        "Optimized image #{optimized_image.width}x#{optimized_image.height} " \
+      "Optimized image #{optimized_image.width}x#{optimized_image.height} " \
         "has only #{frame_count} frame - animation was not preserved"
     end
   end

--- a/spec/jobs/create_avatar_thumbnails_spec.rb
+++ b/spec/jobs/create_avatar_thumbnails_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Jobs::CreateAvatarThumbnails do
   end
 
   it "preserves animation in optimized avatar images",
-    skip: !system("which gifsicle > /dev/null 2>&1") do
+     skip: !system("which gifsicle > /dev/null 2>&1") do
     file = File.open(animated_gif_path)
     upload =
       UploadCreator.new(file, "animated_avatar.gif", type: "avatar", for_user: user).create_for(
@@ -23,9 +23,7 @@ RSpec.describe Jobs::CreateAvatarThumbnails do
     expect(upload.animated?).to eq(true)
 
     # create optimized images
-    Discourse.avatar_sizes.each do |size|
-      OptimizedImage.create_for(upload, size, size)
-    end
+    Discourse.avatar_sizes.each { |size| OptimizedImage.create_for(upload, size, size) }
 
     upload.reload
 

--- a/spec/jobs/create_avatar_thumbnails_spec.rb
+++ b/spec/jobs/create_avatar_thumbnails_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Jobs::CreateAvatarThumbnails do
+  fab!(:user)
+
+  let(:animated_gif_path) { "#{Rails.root}/spec/fixtures/images/animated.gif" }
+
+  before do
+    enable_current_plugin
+    SiteSetting.authorized_extensions = "gif"
+  end
+
+  it "preserves animation in optimized avatar images" do
+    file = File.open(animated_gif_path)
+    upload = UploadCreator.new(
+      file,
+      "animated_avatar.gif",
+      type: "avatar",
+      for_user: user,
+    ).create_for(user.id)
+    file.close
+
+    expect(upload).to be_persisted, "Upload failed: #{upload.errors.full_messages.join(', ')}"
+    expect(upload.animated?).to eq(true)
+
+    # create optimized images
+    Discourse.avatar_sizes.each do |size|
+      result = OptimizedImage.create_for(upload, size, size)
+      puts "Created optimized image #{size}x#{size}: #{result.inspect}" if result.nil?
+    end
+
+    upload.reload
+
+    # Verify at least one optimized image exists
+    expect(upload.optimized_images.count).to be > 0,
+      "No optimized images were created. Check ImageMagick command."
+
+    # Check that optimized images preserve animation (multiple frames)
+    upload.optimized_images.each do |optimized_image|
+      optimized_path = Discourse.store.path_for(optimized_image)
+      frame_count = `identify "#{optimized_path}" 2>/dev/null | wc -l`.strip.to_i
+
+      expect(frame_count).to be > 1,
+        "Optimized image #{optimized_image.width}x#{optimized_image.height} " \
+        "has only #{frame_count} frame - animation was not preserved"
+    end
+  end
+end


### PR DESCRIPTION
- Optimized avatar thumbnails were static because [ImageMagick's [0] flag](https://github.com/discourse/discourse/blob/main/app/models/optimized_image.rb#L232) was extracting only the first frame. 
- Override resize method to use gifsicle for GIF files, which preserves animation.                            
                                     