### PR TITLE
FIX: Preserve animation in optimized GIF avatars (#71)

### DIFF
--- a/lib/discourse_animated_avatars/optimized_image_extension.rb
+++ b/lib/discourse_animated_avatars/optimized_image_extension.rb
@@ -21,6 +21,23 @@ module DiscourseAnimatedAvatars
           %W[--#{resize_method} #{dimensions} --optimize=3 --output #{to} #{from}],
         )
       end
+
+      # Override resize to preserve animation for GIFs
+      def resize(from, to, width, height, opts = {})
+        id = opts[:upload_id]
+        if id && Upload.find_by(id:)&.extension == "gif"
+          # Try to use Gifsicle if available
+          begin
+            return resize_animated(from, to, width, height, opts)
+          rescue => e
+            # Gifsicle not available or failed, log warning and fall back to default
+            Rails.logger.warn(
+              "Gifsicle resize failed for upload #{id}, falling back to ImageMagick: #{e.message}",
+            )
+          end
+        end
+        super
+      end
     end
   end
 end

--- a/spec/jobs/create_avatar_thumbnails_spec.rb
+++ b/spec/jobs/create_avatar_thumbnails_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::CreateAvatarThumbnails do
+  fab!(:user)
+
+  let(:animated_gif_path) { "#{Rails.root}/spec/fixtures/images/animated.gif" }
+
+  before do
+    enable_current_plugin
+    SiteSetting.authorized_extensions = "gif"
+  end
+
+  it "preserves animation in optimized avatar images",
+     skip: !system("which gifsicle > /dev/null 2>&1") do
+    file = File.open(animated_gif_path)
+    upload =
+      UploadCreator.new(file, "animated_avatar.gif", type: "avatar", for_user: user).create_for(
+        user.id,
+      )
+    file.close
+
+    expect(upload).to be_persisted, "Upload failed: #{upload.errors.full_messages.join(", ")}"
+    expect(upload.animated?).to eq(true)
+
+    # create optimized images
+    Discourse.avatar_sizes.each { |size| OptimizedImage.create_for(upload, size, size) }
+
+    upload.reload
+
+    # Verify at least one optimized image exists
+    expect(upload.optimized_images.count).to be > 0,
+    "No optimized images were created. Check ImageMagick command."
+
+    # Check that optimized images preserve animation (multiple frames)
+    upload.optimized_images.each do |optimized_image|
+      optimized_path = Discourse.store.path_for(optimized_image)
+      frame_count = `identify "#{optimized_path}" 2>/dev/null | wc -l`.strip.to_i
+
+      expect(frame_count).to be > 1,
+      "Optimized image #{optimized_image.width}x#{optimized_image.height} " \
+        "has only #{frame_count} frame - animation was not preserved"
+    end
+  end
+end


### PR DESCRIPTION
* FIX: Preserve animation in optimized GIF avatars

* Lint

* review suggestions

* lint files